### PR TITLE
Added Testing & Utilities.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@
 #
 project(FieldCalibration C CXX)
 
+# An option to enable testing, enable it with "cmake blabla -DTESTING=On"
+option(TESTING "Testing" OFF)
+
 #----------------------------------------------------------------------------
 # cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 #
@@ -47,8 +50,19 @@ find_package (Threads)
 #----------------------------------------------------------------------------
 # Add sources and headers
 #
-set(SOURCE_FILES source/Laser.cpp source/LaserTrack.cpp source/Laser.cpp source/Matrix3x3.cpp source/TPCVolumeHandler source/Interpolation3D.cpp)
-set(HEADER_FILES include/Laser.hpp include/LaserTrack.hpp include/Laser.hpp include/ThreeVector.hpp include/Matrix3x3.hpp include/TPCVolumeHandler include/Interpolation3D.hpp)
+include_directories(./include)
+
+set(SOURCE_FILES
+        source/Laser.cpp
+        source/LaserTrack.cpp
+        source/Laser.cpp
+        source/Matrix3x3.cpp
+        source/TPCVolumeHandler
+        source/Interpolation3D.cpp
+        source/Utilities.cpp
+        )
+
+#set(HEADER_FILES include/Laser.hpp include/LaserTrack.hpp include/Laser.hpp include/ThreeVector.hpp include/Matrix3x3.hpp include/TPCVolumeHandler include/Interpolation3D.hpp source/Utilities.cpp include/Utilities.hpp)
 
 #----------------------------------------------------------------------------
 # Locate sources and headers for this project
@@ -57,9 +71,13 @@ include_directories(${ROOT_INCLUDE_DIR})
 
 
 #----------------------------------------------------------------------------
-# Add the executable, and link it to the Geant4 libraries
+# Add the executable, and link it to the necessary libraries
 #
-add_executable(FieldCal FieldCal.cpp ${HEADER_FILES} ${SOURCE_FILES} )
+if(TESTING)
+  add_library(fieldcal SHARED ${SOURCE_FILES} )
+endif()
+
+add_executable(FieldCal FieldCal.cpp ${SOURCE_FILES} tests/test_template.cpp)
 target_link_libraries(FieldCal ${ROOT_LIBRARIES} ${CGAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 #----------------------------------------------------------------------------
@@ -76,8 +94,21 @@ target_link_libraries(FieldCal ${ROOT_LIBRARIES} ${CGAL_LIBRARIES} ${CMAKE_THREA
 #endforeach()
 
 
+# Testing stuff
+if(TESTING)
+  find_package(GTest REQUIRED)
+  if( GTEST_FOUND )
+    enable_testing()
+    add_subdirectory(tests)
+  else()
+    message(STATUS "Cannot find GTest, which is required if testing is enabled. Either install GTest or disable
+            Testing again.")
+  endif()
+endif()
+
 #----------------------------------------------------------------------------
 # Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
 #
 install(TARGETS FieldCal DESTINATION ${CMAKE_SOURCE_DIR}/bin)
+#install(TARGETS fieldcal DESTINATION ${CMAKE_SOURCE_DIR}/lib )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@
 #
 project(FieldCalibration C CXX)
 
+# An option to enable testing, enable it with "cmake blabla -DTESTING=On"
+option(TESTING "Testing" OFF)
+
 #----------------------------------------------------------------------------
 # cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
 #
@@ -47,8 +50,19 @@ find_package (Threads)
 #----------------------------------------------------------------------------
 # Add sources and headers
 #
-set(SOURCE_FILES source/Laser.cpp source/LaserTrack.cpp source/Laser.cpp source/Matrix3x3.cpp source/TPCVolumeHandler source/Interpolation3D.cpp)
-set(HEADER_FILES include/Laser.hpp include/LaserTrack.hpp include/Laser.hpp include/ThreeVector.hpp include/Matrix3x3.hpp include/TPCVolumeHandler include/Interpolation3D.hpp)
+include_directories(./include)
+
+set(SOURCE_FILES
+        source/Laser.cpp
+        source/LaserTrack.cpp
+        source/Laser.cpp
+        source/Matrix3x3.cpp
+        source/TPCVolumeHandler
+        source/Interpolation3D.cpp
+        source/Utilities.cpp
+        )
+
+#set(HEADER_FILES include/Laser.hpp include/LaserTrack.hpp include/Laser.hpp include/ThreeVector.hpp include/Matrix3x3.hpp include/TPCVolumeHandler include/Interpolation3D.hpp source/Utilities.cpp include/Utilities.hpp)
 
 #----------------------------------------------------------------------------
 # Locate sources and headers for this project
@@ -57,9 +71,13 @@ include_directories(${ROOT_INCLUDE_DIR})
 
 
 #----------------------------------------------------------------------------
-# Add the executable, and link it to the Geant4 libraries
+# Add the executable, and link it to the necessary libraries
 #
-add_executable(FieldCal FieldCal.cpp ${HEADER_FILES} ${SOURCE_FILES} )
+if(TESTING)
+  add_library(fieldcal SHARED ${SOURCE_FILES} )
+endif()
+
+add_executable(FieldCal FieldCal.cpp ${SOURCE_FILES} tests/test_template.cpp)
 target_link_libraries(FieldCal ${ROOT_LIBRARIES} ${CGAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 #----------------------------------------------------------------------------
@@ -76,8 +94,21 @@ target_link_libraries(FieldCal ${ROOT_LIBRARIES} ${CGAL_LIBRARIES} ${CMAKE_THREA
 #endforeach()
 
 
+# Testing stuff
+if(TESTING)
+  find_package(GTest REQUIRED)
+  if( GTEST_FOUND )
+    enable_testing()
+    add_subdirectory(tests)
+  else()
+    message(STATUS "Cannot find GTest, which is required if testing is enabled. Either install GTest or disable
+            Testing again.")
+  endif()
+endif()
+
 #----------------------------------------------------------------------------
 # Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
 #
-install(TARGETS FieldCal DESTINATION bin)
+install(TARGETS FieldCal DESTINATION ${CMAKE_SOURCE_DIR}/bin)
+#install(TARGETS fieldcal DESTINATION ${CMAKE_SOURCE_DIR}/lib )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if(TESTING)
   add_library(fieldcal SHARED ${SOURCE_FILES} )
 endif()
 
-add_executable(FieldCal FieldCal.cpp ${SOURCE_FILES} tests/test_template.cpp)
+add_executable(FieldCal FieldCal.cpp ${SOURCE_FILES})
 target_link_libraries(FieldCal ${ROOT_LIBRARIES} ${CGAL_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 #----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,11 @@ endif()
 #----------------------------------------------------------------------------
 # Use C++11 extention and O3 optimization (-founding-math because of CGAL)
 #
-set(CMAKE_CXX_FLAGS "-O3 -frounding-math")
+if (APPLE)
+  message(STATUS "No optimization for mac :-)")
+else()
+  set(CMAKE_CXX_FLAGS "-O3 -frounding-math")
+endif()
 add_definitions("-std=c++11")
 
 #----------------------------------------------------------------------------
@@ -67,7 +71,13 @@ set(SOURCE_FILES
 #----------------------------------------------------------------------------
 # Locate sources and headers for this project
 #
-include_directories(${ROOT_INCLUDE_DIR})
+if (APPLE)
+  message(STATUS "So Yifan is trying somethings.")
+  execute_process(COMMAND "root-config" "--incdir" OUTPUT_VARIABLE rootinc RESULT_VARIABLE rs)
+  include_directories(${rootinc})
+else()
+  include_directories(${ROOT_INCLUDE_DIR})
+endif()
 
 
 #----------------------------------------------------------------------------

--- a/FieldCal.cpp
+++ b/FieldCal.cpp
@@ -265,7 +265,4 @@ void WriteTextFile(std::vector<ThreeVector<float>>& InterpolationData)
 void LaserInterpThread(Laser& LaserTrackSet, const Laser& InterpolationLaser, const Delaunay& InterpolationMesh)
 {
   LaserTrackSet.InterpolateTrackSet(InterpolationLaser, InterpolationMesh);
-} // LaserInterpThread
-
-// Split the laser track set into tracks that reached the expected exit point (within a configurable region) and others.
-// First entry of the return vector is tracks that reach the exit point, second is the ones that do not reach it.
+} // LaserInterpThread  

--- a/FieldCal.cpp
+++ b/FieldCal.cpp
@@ -269,22 +269,3 @@ void LaserInterpThread(Laser& LaserTrackSet, const Laser& InterpolationLaser, co
 
 // Split the laser track set into tracks that reached the expected exit point (within a configurable region) and others.
 // First entry of the return vector is tracks that reach the exit point, second is the ones that do not reach it.
-std::vector<Laser> ReachedExitPoint(const Laser& LaserSet, float MaxDeviation) {
-
-    std::vector<Laser> Selection;
-    Selection.resize(2);
-
-    for(auto& Track : LaserSet.GetTrackSet())
-    {
-        auto Residual = Track.GetExitPoint() - Track.GetBack();
-        auto Distance = Residual.GetNorm();
-
-        if (Distance < MaxDeviation) {
-            Selection.front().AppendTrack(Track);
-        }
-        else {
-            Selection.back().AppendTrack(Track);
-        }
-    }
-    return Selection;
-}

--- a/include/Utilities.hpp
+++ b/include/Utilities.hpp
@@ -9,4 +9,6 @@
 
 #include "Laser.hpp"
 
+// Split the laser track set into tracks that reached the expected exit point (within a configurable region) and others.
+// First entry of the return vector is tracks that reach the exit point, second is the ones that do not reach it.
 std::vector<Laser> ReachedExitPoint(const Laser&, float);

--- a/include/Utilities.hpp
+++ b/include/Utilities.hpp
@@ -1,0 +1,12 @@
+//
+// Created by matthias on 28.04.17.
+//
+
+#ifndef FIELDCALIBRATION_UTILITIES_H
+#define FIELDCALIBRATION_UTILITIES_H
+
+#endif //FIELDCALIBRATION_UTILITIES_H
+
+#include "Laser.hpp"
+
+std::vector<Laser> ReachedExitPoint(const Laser&, float);

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -1,0 +1,25 @@
+//
+// Created by matthias on 28.04.17.
+//
+
+#include "../include/Utilities.hpp"
+
+std::vector<Laser> ReachedExitPoint(const Laser& LaserSet, float ExitBoundary) {
+
+    std::vector<Laser> Selection;
+    Selection.resize(2);
+
+    for(auto& Track : LaserSet.GetTrackSet())
+    {
+        auto ExitToLast = Track.GetExitPoint() - Track.GetBack();
+        auto d = ExitToLast.GetNorm();
+
+        if (d < ExitBoundary) {
+            Selection.front().AppendTrack(Track);
+        }
+        else {
+            Selection.back().AppendTrack(Track);
+        }
+    }
+    return Selection;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Testing stuff. I use gtest for testing, for instruction on how to install or use it
+# go here https://github.com/google/googletest and click around. A test template file
+# is supplied too. Just add your new test to the TEST_FILES Variable.
+
+include_directories(${GTEST_INCLUDE_DIRS} ${ROOT_INCLUDE_DIR} ${CMAKE_SOURCE_DIR}/include)
+
+# Add any further test files here
+set(TEST_FILES
+        test_splitter.cpp
+        )
+
+add_executable(RunTests ${TEST_FILES})
+target_link_libraries(RunTests gtest fieldcal ${ROOT_LIBRARIES} -lpthread -lm)

--- a/tests/test_splitter.cpp
+++ b/tests/test_splitter.cpp
@@ -1,0 +1,55 @@
+//
+// Created by matthias on 28.04.17.
+//
+
+#include <TVector3.h>
+
+#include <gtest/gtest.h>
+#include "../include/Utilities.hpp"
+
+// Tests factorial of 0.
+TEST(TestSplitter, CheckSelection) {
+
+    TVector3 entry(1.,1.,1.);
+    TVector3 exit(0.,0.,0.);
+
+    std::vector<TVector3> RecobLaserTrack;
+
+    // fill the dummy vector in the right order. Tracks are assumed to be filled ordered,
+    // starting at the entry point and ending closest to the exit point.
+    for (int i=9; i > 0; i--){
+        const float pt = i / 10.0;
+        RecobLaserTrack.push_back(TVector3(pt,pt,pt));
+    }
+
+    // Make a laser track out of entry, exit and track points. Then add it to the Laser collection
+    LaserTrack Track1 = LaserTrack(entry, exit, RecobLaserTrack);
+    std::vector<LaserTrack> PewPew{ Track1 };
+    Laser Las(PewPew);
+
+    // Now the actual testing of the function follows
+    // Check if track gets into the first selection:
+    auto res = ReachedExitPoint(PewPew, 0.5);
+    auto InSelection = res.front();
+    auto OutSelection = res.back();
+    ASSERT_EQ(InSelection.GetNumberOfTracks(), 1);
+    ASSERT_EQ(OutSelection.GetNumberOfTracks(), 0);
+    res.clear();
+
+    // Check if track gets into the second selection under new condition:
+    res = ReachedExitPoint(PewPew, 0.001);
+    InSelection = res.front();
+    OutSelection = res.back();
+    ASSERT_EQ(InSelection.GetNumberOfTracks(), 0);
+    ASSERT_EQ(OutSelection.GetNumberOfTracks(), 1);
+
+    //float a = 1;
+    ASSERT_TRUE(true);
+    //EXPECT_EQ(1, ReachedExitPoint(Test, 1));
+}
+
+int main(int ac, char* av[])
+{
+    testing::InitGoogleTest(&ac, av);
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_template.cpp
+++ b/tests/test_template.cpp
@@ -1,0 +1,9 @@
+//
+// Created by matthias on 01.05.17.
+//
+
+#include <gtest/gtest.h>
+
+TEST(TestTitle, TestSubtitle) {
+    ASSERT_FALSE(false);
+}


### PR DESCRIPTION
I added testing possibilities to the cmake structure. The testing framework used is googletest and is pretty easy to install (and use) (see [here](https://github.com/google/googletest)):

1. Clone repository into $GTEST
2. Make a build folder somewhere
3. cmake $GTEST
4. (sudo ) make install

Then to enable testing within the project I added a testing flag to cmake (use it with -DTESTING=On).
To get an idea on how to write test, look into the test folder. There is also a template.cpp for tests. To make testing work properly and efficiently I had to add the compilation of a shared library, which makes all the code easily available for includes. But I guess the *.so should not be used.