### PR TITLE
Implement downselection of input data set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ target_link_libraries(FieldCal ${ROOT_LIBRARIES} ${CGAL_LIBRARIES} ${CMAKE_THREA
 
 # Testing stuff
 if(TESTING)
+  message(STATUS "Testing enabled.")
   find_package(GTest REQUIRED)
   if( GTEST_FOUND )
     enable_testing()

--- a/FieldCal.cpp
+++ b/FieldCal.cpp
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
     // Calculate track displacement
     std::cout << "Find track displacements... " << std::endl;
     // Choose displacement algorithm (available so far: TrackDerivative, ClosestPoint, or LinearStretch)
-    LaserTrackSet.CalcDisplacement(LaserTrack::LinearStretch);
+    LaserTrackSet.CalcDisplacement(LaserTrack::ClosestPoint);
     
     // Add displacement to reconstructed track to change to detector coordinates (only for map generation)
     LaserTrackSet.AddCorrectionToReco();

--- a/include/LaserTrack.hpp
+++ b/include/LaserTrack.hpp
@@ -78,7 +78,7 @@ public:
   void AppendSample(float SamplePos_x, float SamplePos_y, float SamplePos_z, float SampleCorr_x, float SampleCorr_y, float SampleCorr_z);
   void AppendSample(float,float,float);
 
-    std::vector<ThreeVector<float>> GetTrack();
+    std::vector<ThreeVector<float>> GetReco();
   
   static void DistortTracks(std::vector<LaserTrack>&, const std::string&, const TPCVolumeHandler&);
 };

--- a/include/LaserTrack.hpp
+++ b/include/LaserTrack.hpp
@@ -46,6 +46,7 @@ public:
   
   // Constructor with reco data input with entry point, exit point, and reco track 
   LaserTrack(const TVector3& InEntryPoint, const TVector3& InExitPoint, const std::vector<TVector3>& RecoTrack);
+    LaserTrack(const ThreeVector<float>& InEntryPoint, const ThreeVector<float>& InExitPoint, const std::vector<ThreeVector<float>>& RecoTrack);
   LaserTrack(std::array<float,2>&, ThreeVector<float>&, const TPCVolumeHandler&);
   LaserTrack(const unsigned int,std::array<float,2>&, ThreeVector<float>&, const TPCVolumeHandler&);
 
@@ -76,6 +77,8 @@ public:
   void AppendSample(ThreeVector<float>&);
   void AppendSample(float SamplePos_x, float SamplePos_y, float SamplePos_z, float SampleCorr_x, float SampleCorr_y, float SampleCorr_z);
   void AppendSample(float,float,float);
+
+    std::vector<ThreeVector<float>> GetTrack();
   
   static void DistortTracks(std::vector<LaserTrack>&, const std::string&, const TPCVolumeHandler&);
 };

--- a/include/Utilities.hpp
+++ b/include/Utilities.hpp
@@ -10,3 +10,5 @@
 #include "Laser.hpp"
 
 std::vector<Laser> ReachedExitPoint(const Laser&, float);
+
+std::vector<Laser> SplitTrackSet(const Laser&, unsigned int);

--- a/source/LaserTrack.cpp
+++ b/source/LaserTrack.cpp
@@ -27,6 +27,27 @@ LaserTrack::LaserTrack(const TVector3& InEntryPoint, const TVector3& InExitPoint
     LaserDisplacement.resize(LaserReco.size());
 }
 
+// Constructor used for reconstructed laser data
+LaserTrack::LaserTrack(const ThreeVector<float>& InEntryPoint, const ThreeVector<float>& InExitPoint, const std::vector<ThreeVector<float>>& RecoTrack)
+{
+    // Resever enogh space for the LaserReco vector. Can be important if you go to the Memory limit
+    LaserReco.reserve(RecoTrack.size());
+
+    // Store entry and exit point
+    EntryPoint = InEntryPoint;
+    ExitPoint = InExitPoint;
+
+    // Loop over all RecoTrack points
+    for(const auto & TrackPoint : RecoTrack)
+    {
+        // Fill TrackPoints as vectors into the LaserReco vector
+        LaserReco.push_back(TrackPoint);
+    }
+
+    // Initialize LaserDisplacement vector
+    LaserDisplacement.resize(LaserReco.size());
+}
+
 LaserTrack::LaserTrack(std::array<float,2>& Angles, ThreeVector<float>& Position, const TPCVolumeHandler& TPCVolume) : TrackAngles(Angles) , LaserPosition(Position)
 {  
   FindBoundaries(TPCVolume);
@@ -418,6 +439,10 @@ void LaserTrack::DistortTracks(std::vector<LaserTrack>& LaserTracks, const std::
   FieldFile->Close();
   delete FieldFile;
   gDirectory->GetList()->Delete();
+}
+
+std::vector<ThreeVector<float>> LaserTrack::GetTrack() {
+    return LaserReco;
 }
 
 ThreeVector<float> LaserTrack::GetFront() const {

--- a/source/LaserTrack.cpp
+++ b/source/LaserTrack.cpp
@@ -441,7 +441,7 @@ void LaserTrack::DistortTracks(std::vector<LaserTrack>& LaserTracks, const std::
   gDirectory->GetList()->Delete();
 }
 
-std::vector<ThreeVector<float>> LaserTrack::GetTrack() {
+std::vector<ThreeVector<float>> LaserTrack::GetReco() {
     return LaserReco;
 }
 

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -5,6 +5,12 @@
 #include "../include/Utilities.hpp"
 
 std::vector<Laser> ReachedExitPoint(const Laser& LaserSet, float ExitBoundary) {
+    /*
+     * Function that splits the input data set into two sets. The first set contains the
+     * tracks that have a distance between the last reconstructed point and the expected
+     * exit point smaller than the specified distance (ExitBoundary). All other LaserTracks
+     * will be put in the second set.
+     */
 
     std::vector<Laser> Selection;
     Selection.resize(2);
@@ -25,6 +31,10 @@ std::vector<Laser> ReachedExitPoint(const Laser& LaserSet, float ExitBoundary) {
 }
 
 std::vector<Laser> SplitTrackSet(const Laser& LaserSet, unsigned int Downsample) {
+    /*
+     * This function separates the input laser data set into multiple smaller data sets,
+     * the number of produced set is specified by the Downsample value.
+     */
     std::vector<Laser> Sets;
     Sets.resize(Downsample);
 
@@ -32,9 +42,8 @@ std::vector<Laser> SplitTrackSet(const Laser& LaserSet, unsigned int Downsample)
     {
 
         auto SourceTrack = Track.GetReco();
-        unsigned long TrackSize = Track.GetNumberOfSamples();
 
-        for (unsigned long offset=0; offset < Sets.size(); offset++){
+        for (unsigned long offset=0; offset < Downsample; offset++){
             std::vector<ThreeVector<float>> SampledRecoTrack;
 
             for (unsigned long idx=offset; idx < SourceTrack.size(); idx += Downsample) {

--- a/source/Utilities.cpp
+++ b/source/Utilities.cpp
@@ -23,3 +23,28 @@ std::vector<Laser> ReachedExitPoint(const Laser& LaserSet, float ExitBoundary) {
     }
     return Selection;
 }
+
+std::vector<Laser> SplitTrackSet(const Laser& LaserSet, unsigned int Downsample) {
+    std::vector<Laser> Sets;
+    Sets.resize(Downsample);
+
+    for(auto& Track : LaserSet.GetTrackSet())
+    {
+
+        auto SourceTrack = Track.GetReco();
+        unsigned long TrackSize = Track.GetNumberOfSamples();
+
+        for (unsigned long offset=0; offset < Sets.size(); offset++){
+            std::vector<ThreeVector<float>> SampledRecoTrack;
+
+            for (unsigned long idx=offset; idx < SourceTrack.size(); idx += Downsample) {
+                SampledRecoTrack.push_back(SourceTrack[idx]);
+            }
+            LaserTrack SampledTrack(Track.GetEntryPoint(), Track.GetExitPoint(), SampledRecoTrack);
+            Sets[offset].AppendTrack(SampledTrack);
+            SampledRecoTrack.clear();
+
+        }
+    }
+    return Sets;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${GTEST_INCLUDE_DIRS} ${ROOT_INCLUDE_DIR} ${CMAKE_SOURCE_DIR
 
 # Add any further test files here
 set(TEST_FILES
-        test_splitter.cpp
+        test_utilities.cpp
         )
 
 add_executable(RunTests ${TEST_FILES})

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -175,7 +175,7 @@ TEST(TestDownsampler, TwoTracks) {
     for (int i=1; i < 11; i++){
         const float pt = i;
         RecobLaserTrack1.push_back(TVector3(pt,pt,pt));
-        RecobLaserTrack1.push_back(TVector3(-pt,-pt,-pt));
+        RecobLaserTrack2.push_back(TVector3(-pt,-pt,-pt));
     }
 
     // Make a laser track out of entry, exit and track points. Then add it to the Laser collection

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -1,0 +1,217 @@
+//
+// Created by matthias on 28.04.17.
+//
+
+#include <TVector3.h>
+
+#include <gtest/gtest.h>
+#include "../include/Utilities.hpp"
+
+// Tests factorial of 0.
+TEST(TestSplitter, CheckSelection) {
+
+    TVector3 entry(1.,1.,1.);
+    TVector3 exit(0.,0.,0.);
+
+    std::vector<TVector3> RecobLaserTrack;
+
+    // fill the dummy vector in the right order. Tracks are assumed to be filled ordered,
+    // starting at the entry point and ending closest to the exit point.
+    for (int i=9; i > 0; i--){
+        const float pt = i / 10.0;
+        RecobLaserTrack.push_back(TVector3(pt,pt,pt));
+    }
+
+    // Make a laser track out of entry, exit and track points. Then add it to the Laser collection
+    LaserTrack Track1 = LaserTrack(entry, exit, RecobLaserTrack);
+    std::vector<LaserTrack> PewPew{ Track1 };
+    Laser Las(PewPew);
+
+    // Now the actual testing of the function follows
+    // Check if track gets into the first selection:
+    auto res = ReachedExitPoint(PewPew, 0.5);
+    auto InSelection = res.front();
+    auto OutSelection = res.back();
+    ASSERT_EQ(InSelection.GetNumberOfTracks(), 1);
+    ASSERT_EQ(OutSelection.GetNumberOfTracks(), 0);
+    res.clear();
+
+    // Check if track gets into the second selection under new condition:
+    res = ReachedExitPoint(PewPew, 0.001);
+    InSelection = res.front();
+    OutSelection = res.back();
+    ASSERT_EQ(InSelection.GetNumberOfTracks(), 0);
+    ASSERT_EQ(OutSelection.GetNumberOfTracks(), 1);
+
+    //float a = 1;
+    ASSERT_TRUE(true);
+    //EXPECT_EQ(1, ReachedExitPoint(Test, 1));
+}
+
+TEST(TestDownsampler, SplitSingleEvenTrack) {
+
+    TVector3 entry(1.,1.,1.);
+    TVector3 exit(0.,0.,0.);
+
+    std::vector<TVector3> RecobLaserTrack;
+
+    // fill the dummy vector in the right order. Tracks are assumed to be filled ordered,
+    // starting at the entry point and ending closest to the exit point.
+    for (int i=0; i < 10; i++){
+        const float pt = i;
+        RecobLaserTrack.push_back(TVector3(pt,pt,pt));
+    }
+
+    // Make a laser track out of entry, exit and track points. Then add it to the Laser collection
+    LaserTrack Track1 = LaserTrack(entry, exit, RecobLaserTrack);
+    std::vector<LaserTrack> PewPew{ Track1 };
+    Laser Las(PewPew);
+
+    std::vector<Laser> LaserSets = SplitTrackSet(Las, 2);
+
+    auto first_set = LaserSets.front();
+    auto first_track = first_set.GetFirstTrack();
+
+    ASSERT_TRUE(first_track.GetReco().front() == ThreeVector<float>(0., 0., 0.));
+    ASSERT_TRUE(first_track.GetReco().back() == ThreeVector<float>(8., 8., 8.));
+    ASSERT_EQ(first_track.GetNumberOfSamples(), 5);
+
+    auto second_set = LaserSets.back();
+    auto second_track = second_set.GetFirstTrack();
+
+    ASSERT_TRUE(second_track.GetReco().front() == ThreeVector<float>(1., 1., 1.));
+    ASSERT_TRUE(second_track.GetReco().back() == ThreeVector<float>(9., 9., 9.));
+    ASSERT_EQ(second_track.GetNumberOfSamples(), 5);
+}
+
+TEST(TestDownsampler, SplitSingleOddTrack) {
+
+    TVector3 entry(1.,1.,1.);
+    TVector3 exit(0.,0.,0.);
+
+    std::vector<TVector3> RecobLaserTrack;
+
+    // fill the dummy vector in the right order. Tracks are assumed to be filled ordered,
+    // starting at the entry point and ending closest to the exit point.
+    for (int i=0; i < 11; i++){
+        const float pt = i;
+        RecobLaserTrack.push_back(TVector3(pt,pt,pt));
+    }
+
+    // Make a laser track out of entry, exit and track points. Then add it to the Laser collection
+    LaserTrack Track1 = LaserTrack(entry, exit, RecobLaserTrack);
+    std::vector<LaserTrack> PewPew{ Track1 };
+    Laser Las(PewPew);
+
+    std::vector<Laser> LaserSets = SplitTrackSet(Las, 2);
+
+    auto first_set = LaserSets.front();
+    auto first_track = first_set.GetFirstTrack();
+
+    ASSERT_TRUE(first_track.GetReco().front() == ThreeVector<float>(0., 0., 0.));
+    ASSERT_TRUE(first_track.GetReco().back() == ThreeVector<float>(10., 10., 10.));
+    ASSERT_EQ(first_track.GetNumberOfSamples(), 6);
+
+    auto second_set = LaserSets.back();
+    auto second_track = second_set.GetFirstTrack();
+
+    ASSERT_TRUE(second_track.GetReco().front() == ThreeVector<float>(1., 1., 1.));
+    ASSERT_TRUE(second_track.GetReco().back() == ThreeVector<float>(9., 9., 9.));
+    ASSERT_EQ(second_track.GetNumberOfSamples(), 5);
+}
+
+TEST(TestDownsampler, HigherOrder) {
+
+    TVector3 entry(1.,1.,1.);
+    TVector3 exit(0.,0.,0.);
+
+    std::vector<TVector3> RecobLaserTrack;
+
+    // fill the dummy vector in the right order. Tracks are assumed to be filled ordered,
+    // starting at the entry point and ending closest to the exit point.
+    for (int i=1; i < 11; i++){
+        const float pt = i;
+        RecobLaserTrack.push_back(TVector3(pt,pt,pt));
+    }
+
+    // Make a laser track out of entry, exit and track points. Then add it to the Laser collection
+    LaserTrack Track1 = LaserTrack(entry, exit, RecobLaserTrack);
+    std::vector<LaserTrack> PewPew{ Track1 };
+    Laser Las(PewPew);
+
+    std::vector<Laser> LaserSets = SplitTrackSet(Las, 4);
+
+    ASSERT_EQ(LaserSets.size(), 4);
+
+    auto first_set = LaserSets[0];
+    auto first_track = first_set.GetFirstTrack();
+
+    ASSERT_TRUE(first_track.GetReco().front() == ThreeVector<float>(1., 1., 1.));
+    ASSERT_TRUE(first_track.GetReco()[1] == ThreeVector<float>(5., 5., 5.));
+    ASSERT_TRUE(first_track.GetReco().back() == ThreeVector<float>(9., 9., 9.));
+    ASSERT_EQ(first_track.GetNumberOfSamples(), 3);
+
+    auto second_set = LaserSets.back();
+    auto second_track = second_set.GetFirstTrack();
+
+    ASSERT_TRUE(second_track.GetReco().front() == ThreeVector<float>(4., 4., 4.));
+    ASSERT_TRUE(second_track.GetReco().back() == ThreeVector<float>(8., 8., 8.));
+    ASSERT_EQ(second_track.GetNumberOfSamples(), 2);
+
+    ASSERT_EQ(LaserSets[1].GetFirstTrack().GetNumberOfSamples(), 3);
+    ASSERT_EQ(LaserSets[2].GetFirstTrack().GetNumberOfSamples(), 2);
+}
+
+TEST(TestDownsampler, TwoTracks) {
+
+    TVector3 entry(1.,1.,1.);
+    TVector3 exit(0.,0.,0.);
+
+    std::vector<TVector3> RecobLaserTrack1;
+    std::vector<TVector3> RecobLaserTrack2;
+
+    // fill the dummy vector in the right order. Tracks are assumed to be filled ordered,
+    // starting at the entry point and ending closest to the exit point.
+    for (int i=1; i < 11; i++){
+        const float pt = i;
+        RecobLaserTrack1.push_back(TVector3(pt,pt,pt));
+        RecobLaserTrack1.push_back(TVector3(-pt,-pt,-pt));
+    }
+
+    // Make a laser track out of entry, exit and track points. Then add it to the Laser collection
+    LaserTrack Track1 = LaserTrack(entry, exit, RecobLaserTrack1);
+    LaserTrack Track2 = LaserTrack(entry, exit, RecobLaserTrack2);
+    std::vector<LaserTrack> PewPew{ Track1, Track2 };
+    Laser Las(PewPew);
+
+    std::vector<Laser> LaserSets = SplitTrackSet(Las, 2);
+
+    ASSERT_EQ(LaserSets.size(), 2);
+
+    auto first_set = LaserSets[0];
+    auto second_set = LaserSets[1];
+
+    ASSERT_EQ( first_set.GetNumberOfTracks(), 2);
+    ASSERT_EQ(second_set.GetNumberOfTracks(), 2);
+
+    auto reco_set0_track0 = first_set.GetTrack(0);
+    auto reco_set0_track1 = first_set.GetTrack(1);
+
+    auto reco_set1_track0 = second_set.GetTrack(0);
+    auto reco_set1_track1 = second_set.GetTrack(1);
+
+
+    ASSERT_TRUE(reco_set0_track0.GetReco().front() == ThreeVector<float>(1., 1., 1.));
+    ASSERT_TRUE(reco_set1_track0.GetReco().front() == ThreeVector<float>(2., 2., 2.));
+
+    ASSERT_TRUE(reco_set0_track1.GetReco().front() == ThreeVector<float>(-1., -1., -1.));
+    ASSERT_TRUE(reco_set1_track1.GetReco().front() == ThreeVector<float>(-2., -2., -2.));
+
+}
+
+
+int main(int ac, char* av[])
+{
+    testing::InitGoogleTest(&ac, av);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
An implementation that splits the input data sample for further processing. This should help with considering more data points than just the closest ones to a grid point in the full data set. The multiple processed subset are averaged at the end.  